### PR TITLE
修复 edn 转 msgpack-kw 丢失命名空间问题 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject robertluo/ring-middleware-format "0.9.0"
+(defproject robertluo/ring-middleware-format "0.8.1"
   :description "Ring middleware for parsing parameters and emitting
   responses in various formats (mainly JSON, YAML and Transit out of
   the box)"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject robertluo/ring-middleware-format "0.8.0"
+(defproject robertluo/ring-middleware-format "0.9.0"
   :description "Ring middleware for parsing parameters and emitting
   responses in various formats (mainly JSON, YAML and Transit out of
   the box)"

--- a/src/ring/middleware/format_response.clj
+++ b/src/ring/middleware/format_response.clj
@@ -5,7 +5,6 @@
             [clojure.java.io :as io]
             [clj-yaml.core :as yaml]
             [clojure.string :as s]
-            [clojure.walk :refer [stringify-keys]]
             [cognitect.transit :as transit]
             [msgpack.core :as msgpack])
   (:use [clojure.core.memoize :only [lu]])
@@ -251,6 +250,14 @@
       (assoc options :encoders [(make-encoder
                                   (if hf generate-hf-clojure (or encoder generate-native-clojure))
                                   (or type "application/edn"))]))))
+
+(defn stringify-keys
+  "Recursively transforms all map keys from keywords to strings with namespace."
+  {:added "1.1"}
+  [m]
+  (let [f (fn [[k v]] (if (keyword? k) [(subs (str k) 1) v] [k v]))]
+    ;; only apply to maps
+    (clojure.walk/postwalk (fn [x] (if (map? x) (into {} (map f x)) x)) m)))
 
 (defn encode-msgpack [body]
   (with-open [out-stream (ByteArrayOutputStream.)]

--- a/test/ring/middleware/format_params_test.clj
+++ b/test/ring/middleware/format_params_test.clj
@@ -5,8 +5,9 @@
             [clj-yaml.core :as yaml]
             [cognitect.transit :as transit]
             [clojure.java.io :as io]
-            [clojure.walk :refer [stringify-keys keywordize-keys]]
+            [clojure.walk :refer [keywordize-keys]]
             [msgpack.core :as msgpack]
+            [ring.middleware.format-response :refer [stringify-keys]]
             [clojure.string :as string])
   (:import [java.io ByteArrayInputStream ByteArrayOutputStream]))
 
@@ -78,22 +79,22 @@
 
 (deftest augments-with-msgpack-content-type
   (let [req {:content-type "application/msgpack"
-             :body (ByteArrayInputStream. (msgpack/pack (stringify-keys {:foo "bar"})))
+             :body (ByteArrayInputStream. (msgpack/pack (stringify-keys {:ns/foo "bar"})))
              :params {"id" 3}}
              resp (msgpack-echo req)]
-    (is (= {"id" 3 "foo" "bar"} (:params resp)))
-    (is (= {"foo" "bar"} (:body-params resp)))))
+    (is (= {"id" 3 "ns/foo" "bar"} (:params resp)))
+    (is (= {"ns/foo" "bar"} (:body-params resp)))))
 
 (def msgpack-kw-echo
   (wrap-msgpack-kw-params identity))
 
 (deftest augments-with-msgpack-kw-content-type
   (let [req {:content-type "application/msgpack"
-             :body (ByteArrayInputStream. (msgpack/pack (stringify-keys {:foo "bar"})))
+             :body (ByteArrayInputStream. (msgpack/pack (stringify-keys {:ns/foo "bar"})))
              :params {"id" 3}}
              resp (msgpack-kw-echo req)]
-    (is (= {"id" 3 :foo "bar"} (:params resp)))
-    (is (= {:foo "bar"} (:body-params resp)))))
+    (is (= {"id" 3 :ns/foo "bar"} (:params resp)))
+    (is (= {:ns/foo "bar"} (:body-params resp)))))
 
 (def clojure-echo
   (wrap-clojure-params identity))

--- a/test/ring/middleware/format_response_test.clj
+++ b/test/ring/middleware/format_response_test.clj
@@ -4,7 +4,7 @@
         [ring.middleware.format-response])
   (:require [cheshire.core :as json]
             [clj-yaml.core :as yaml]
-            [clojure.walk :refer [stringify-keys keywordize-keys]]
+            [clojure.walk :refer [keywordize-keys]]
             [cognitect.transit :as transit]
             [msgpack.core :as msgpack]
             [clojure.string :as string])
@@ -88,7 +88,7 @@
       (.toByteArray out))))
 
 (deftest format-msgpack-hashmap
-  (let [body {:foo "bar"}
+  (let [body {:ns/foo "bar"}
         req {:body body}
         resp (msgpack-echo req)]
     (is (= body (keywordize-keys (msgpack/unpack (slurp-to-bytes (:body resp))))))
@@ -147,7 +147,7 @@
   (wrap-transit-msgpack-response identity))
 
 (deftest format-transit-msgpack-hashmap
-  (let [body {:foo "bar"}
+  (let [body {:ns/foo "bar"}
         req {:body body}
         resp (transit-msgpack-echo req)]
     (is (= body (read-transit :msgpack (:body resp))))


### PR DESCRIPTION
* `clojure.walk/stringify-keys` 在处理 `qualified-keyword` 时，会丢失 `namespace` 。